### PR TITLE
Quickstarts 1-4 - Missed RequireAuthorization call

### DIFF
--- a/IdentityServer/v6/Quickstarts/1_ClientCredentials/src/Api/Program.cs
+++ b/IdentityServer/v6/Quickstarts/1_ClientCredentials/src/Api/Program.cs
@@ -37,6 +37,6 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization("ApiScope");
 
 app.Run();

--- a/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/Api/Program.cs
+++ b/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/Api/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -36,6 +39,6 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization("ApiScope");
 
 app.Run();

--- a/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/Api/Program.cs
+++ b/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/Api/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -36,6 +39,6 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization("ApiScope");
 
 app.Run();

--- a/IdentityServer/v6/Quickstarts/4_EntityFramework/src/Api/Program.cs
+++ b/IdentityServer/v6/Quickstarts/4_EntityFramework/src/Api/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -36,6 +39,6 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization("ApiScope");
 
 app.Run();


### PR DESCRIPTION
Fixes a missed RequireAuthorization created in quickstarts 1 and copied forward into qs 2-4.