### PR TITLE
Fix swagger 500 error

### DIFF
--- a/IdentityServer/v6/Quickstarts/1_ClientCredentials/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/1_ClientCredentials/src/Api/Controllers/IdentityController.cs
@@ -10,6 +10,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/4_EntityFramework/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/4_EntityFramework/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/5_AspNetIdentity/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/5_AspNetIdentity/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/6_JS_with_backend/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/6_JS_with_backend/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });

--- a/IdentityServer/v6/Quickstarts/6_JS_without_backend/src/Api/Controllers/IdentityController.cs
+++ b/IdentityServer/v6/Quickstarts/6_JS_without_backend/src/Api/Controllers/IdentityController.cs
@@ -7,6 +7,7 @@ namespace Api.Controllers;
 [Authorize]
 public class IdentityController : ControllerBase
 {
+    [HttpGet]
     public IActionResult Get()
     {
         return new JsonResult(from c in User.Claims select new { c.Type, c.Value });


### PR DESCRIPTION
`Api` project's swagger definitions were failing to be generated with error:
```
Ambiguous HTTP method for action - Api.Controllers.IdentityController.Get (Api). 
Actions require an explicit HttpMethod binding for Swagger/OpenAPI 3.0
```
