### PR TITLE
Reject invalid password in Spa sample

### DIFF
--- a/IdentityServer/v6/UserInteraction/SpaLoginUi/IdentityServerWithSpaLogin/wwwroot/login.html
+++ b/IdentityServer/v6/UserInteraction/SpaLoginUi/IdentityServerWithSpaLogin/wwwroot/login.html
@@ -79,7 +79,7 @@
 
             let body = {
                 username: document.querySelector("#uid").value,
-                password: document.querySelector("#uid").value,
+                password: document.querySelector("#pwd").value,
                 returnUrl: returnUrl
             };
 


### PR DESCRIPTION
The front-end was previously sending up the username for both the username and password. Since the users in the `TestUsers.Users` collection on the back-end have the same password as their username, this was allowing someone to login using an invalid password.