### PR TITLE
Quickstarts - Add default configs for google auth

### DIFF
--- a/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/appsettings.json
+++ b/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/appsettings.json
@@ -1,13 +1,19 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "Microsoft.Hosting.Lifetime": "Information",
-                "Microsoft.AspNetCore.Authentication": "Debug",
-                "System": "Warning"
-            }
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.AspNetCore.Authentication": "Debug",
+        "System": "Warning"
+      }
     }
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "set your google client id here, or use dotnet user-secrets to store it",
+      "ClientSecret": "set your google client secret here, or use dotnet user-secrets to store it"
+    }
+  }
 }

--- a/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/appsettings.json
+++ b/IdentityServer/v6/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/appsettings.json
@@ -1,13 +1,19 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "Microsoft.Hosting.Lifetime": "Information",
-                "Microsoft.AspNetCore.Authentication": "Debug",
-                "System": "Warning"
-            }
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.AspNetCore.Authentication": "Debug",
+        "System": "Warning"
+      }
     }
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "set your google client id here, or use dotnet user-secrets to store it",
+      "ClientSecret": "set your google client secret here, or use dotnet user-secrets to store it"
+    }
+  }
 }

--- a/IdentityServer/v6/Quickstarts/4_EntityFramework/src/IdentityServer/appsettings.json
+++ b/IdentityServer/v6/Quickstarts/4_EntityFramework/src/IdentityServer/appsettings.json
@@ -1,13 +1,19 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "Microsoft.Hosting.Lifetime": "Information",
-                "Microsoft.AspNetCore.Authentication": "Debug",
-                "System": "Warning"
-            }
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.AspNetCore.Authentication": "Debug",
+        "System": "Warning"
+      }
     }
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "set your google client id here, or use dotnet user-secrets to store it",
+      "ClientSecret": "set your google client secret here, or use dotnet user-secrets to store it"
+    }
+  }
 }


### PR DESCRIPTION
A non-empty value is required to run "out of the box", otherwise
the google handler will throw when it is added.