### PR TITLE
Rename variable to reflect the context better

### DIFF
--- a/IdentityServer/v5/Quickstarts/4_EntityFramework/src/IdentityServer/Startup.cs
+++ b/IdentityServer/v5/Quickstarts/4_EntityFramework/src/IdentityServer/Startup.cs
@@ -25,7 +25,7 @@ namespace IdentityServer
 
             var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;
             const string connectionString = @"Data Source=Duende.IdentityServer.Quickstart.EntityFramework-5.0.0.db";
-            
+
             var builder = services.AddIdentityServer()
                 .AddTestUsers(TestUsers.Users)
                 .AddConfigurationStore(options =>
@@ -116,9 +116,9 @@ namespace IdentityServer
 
                 if (!context.ApiScopes.Any())
                 {
-                    foreach (var resource in Config.ApiScopes)
+                    foreach (var apiScope in Config.ApiScopes)
                     {
-                        context.ApiScopes.Add(resource.ToEntity());
+                        context.ApiScopes.Add(apiScope.ToEntity());
                     }
                     context.SaveChanges();
                 }

--- a/IdentityServer/v5/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
+++ b/IdentityServer/v5/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
@@ -73,9 +73,9 @@ namespace IdentityServerHost
             if (!context.ApiScopes.Any())
             {
                 Log.Debug("ApiScopes being populated");
-                foreach (var resource in Config.ApiScopes.ToList())
+                foreach (var apiScope in Config.ApiScopes.ToList())
                 {
-                    context.ApiScopes.Add(resource.ToEntity());
+                    context.ApiScopes.Add(apiScope.ToEntity());
                 }
                 context.SaveChanges();
             }

--- a/IdentityServer/v6/Configuration/Permissions/IdentityServer/SeedData.cs
+++ b/IdentityServer/v6/Configuration/Permissions/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v6/Configuration/PipelineRegistration/IdentityServer/SeedData.cs
+++ b/IdentityServer/v6/Configuration/PipelineRegistration/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }
@@ -67,9 +67,9 @@ internal static class SeedData
         if (!context.ApiResources.Any())
         {
             Log.Debug("ApiResources being populated");
-            foreach (var resource in Config.ApiResources.ToList())
+            foreach (var apiScope in Config.ApiResources.ToList())
             {
-                context.ApiResources.Add(resource.ToEntity());
+                context.ApiResources.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v6/Configuration/SimpleDcr/IdentityServer/SeedData.cs
+++ b/IdentityServer/v6/Configuration/SimpleDcr/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v6/Configuration/SoftwareStatement/IdentityServer/SeedData.cs
+++ b/IdentityServer/v6/Configuration/SoftwareStatement/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v6/Quickstarts/4_EntityFramework/src/IdentityServer/HostingExtensions.cs
+++ b/IdentityServer/v6/Quickstarts/4_EntityFramework/src/IdentityServer/HostingExtensions.cs
@@ -38,9 +38,9 @@ internal static class HostingExtensions
 
             if (!context.ApiScopes.Any())
             {
-                foreach (var resource in Config.ApiScopes)
+                foreach (var apiScope in Config.ApiScopes)
                 {
-                    context.ApiScopes.Add(resource.ToEntity());
+                    context.ApiScopes.Add(apiScope.ToEntity());
                 }
                 context.SaveChanges();
             }
@@ -95,9 +95,9 @@ internal static class HostingExtensions
 
         return builder.Build();
     }
-    
+
     public static WebApplication ConfigurePipeline(this WebApplication app)
-    { 
+    {
         app.UseSerilogRequestLogging();
         if (app.Environment.IsDevelopment())
         {
@@ -108,7 +108,7 @@ internal static class HostingExtensions
 
         app.UseStaticFiles();
         app.UseRouting();
-            
+
         app.UseIdentityServer();
 
         app.UseAuthorization();

--- a/IdentityServer/v6/UserInteraction/DynamicProviders/IdentityServerHost/SeedData.cs
+++ b/IdentityServer/v6/UserInteraction/DynamicProviders/IdentityServerHost/SeedData.cs
@@ -72,9 +72,9 @@ namespace IdentityServerHost
             if (!context.ApiScopes.Any())
             {
                 Log.Debug("ApiScopes being populated");
-                foreach (var resource in Config.ApiScopes.ToList())
+                foreach (var apiScope in Config.ApiScopes.ToList())
                 {
-                    context.ApiScopes.Add(resource.ToEntity());
+                    context.ApiScopes.Add(apiScope.ToEntity());
                 }
                 context.SaveChanges();
             }

--- a/IdentityServer/v6/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
+++ b/IdentityServer/v6/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
@@ -73,9 +73,9 @@ namespace IdentityServerHost
             if (!context.ApiScopes.Any())
             {
                 Log.Debug("ApiScopes being populated");
-                foreach (var resource in Config.ApiScopes.ToList())
+                foreach (var apiScope in Config.ApiScopes.ToList())
                 {
-                    context.ApiScopes.Add(resource.ToEntity());
+                    context.ApiScopes.Add(apiScope.ToEntity());
                 }
                 context.SaveChanges();
             }

--- a/IdentityServer/v7/Configuration/Permissions/IdentityServer/SeedData.cs
+++ b/IdentityServer/v7/Configuration/Permissions/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v7/Configuration/PipelineRegistration/IdentityServer/SeedData.cs
+++ b/IdentityServer/v7/Configuration/PipelineRegistration/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v7/Configuration/SimpleDcr/IdentityServer/SeedData.cs
+++ b/IdentityServer/v7/Configuration/SimpleDcr/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v7/Configuration/SoftwareStatement/IdentityServer/SeedData.cs
+++ b/IdentityServer/v7/Configuration/SoftwareStatement/IdentityServer/SeedData.cs
@@ -53,9 +53,9 @@ internal static class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v7/Quickstarts/4_EntityFramework/src/IdentityServer/HostingExtensions.cs
+++ b/IdentityServer/v7/Quickstarts/4_EntityFramework/src/IdentityServer/HostingExtensions.cs
@@ -41,9 +41,9 @@ internal static class HostingExtensions
 
             if (!context.ApiScopes.Any())
             {
-                foreach (var resource in Config.ApiScopes)
+                foreach (var apiScope in Config.ApiScopes)
                 {
-                    context.ApiScopes.Add(resource.ToEntity());
+                    context.ApiScopes.Add(apiScope.ToEntity());
                 }
                 context.SaveChanges();
             }
@@ -84,7 +84,7 @@ internal static class HostingExtensions
                 options.ClientSecret = googleClientSecret;
             });
         }
-            
+
         authenticationBuilder.AddOpenIdConnect("oidc", "Demo IdentityServer", options =>
             {
                 options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
@@ -105,11 +105,11 @@ internal static class HostingExtensions
 
         return builder.Build();
     }
-    
+
     public static WebApplication ConfigurePipeline(this WebApplication app)
-    { 
+    {
         app.UseSerilogRequestLogging();
-    
+
         if (app.Environment.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
@@ -119,7 +119,7 @@ internal static class HostingExtensions
 
         app.UseStaticFiles();
         app.UseRouting();
-            
+
         app.UseIdentityServer();
 
         app.UseAuthorization();

--- a/IdentityServer/v7/UserInteraction/DynamicProviders/IdentityServerHost/SeedData.cs
+++ b/IdentityServer/v7/UserInteraction/DynamicProviders/IdentityServerHost/SeedData.cs
@@ -72,9 +72,9 @@ public class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }

--- a/IdentityServer/v7/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
+++ b/IdentityServer/v7/UserInteraction/WsFederationDynamicProviders/IdentityServerHost/SeedData.cs
@@ -73,9 +73,9 @@ public class SeedData
         if (!context.ApiScopes.Any())
         {
             Log.Debug("ApiScopes being populated");
-            foreach (var resource in Config.ApiScopes.ToList())
+            foreach (var apiScope in Config.ApiScopes.ToList())
             {
-                context.ApiScopes.Add(resource.ToEntity());
+                context.ApiScopes.Add(apiScope.ToEntity());
             }
             context.SaveChanges();
         }


### PR DESCRIPTION
Rename variable to reflect the context better

The variable name, `resource`, is probably copied from the previous loop scope, `IdentityResources`.
If it is, it could be renamed to `apiScope` to reflect the current loop context better.