### PR TITLE
fix: upgrade @angular/ssr to 21.2.0-rc.1, 21.1.5, 20.3.17, 19.2.21 (CVE-2026-27739)

### DIFF
--- a/BFF/v3/Angular/angular.ssr/package-lock.json
+++ b/BFF/v3/Angular/angular.ssr/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/platform-server": "^19.2.0",
         "@angular/router": "^19.2.0",
-        "@angular/ssr": "^19.2.0",
+        "@angular/ssr": "^19.2.21",
         "bootstrap": "^5.3.3",
         "express": "^4.18.2",
         "run-script-os": "*",
@@ -760,9 +760,9 @@
       }
     },
     "node_modules/@angular/ssr": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-19.2.3.tgz",
-      "integrity": "sha512-pv6XaFpFwlkgojDSppDriRLxEoUM/JKCnHu/UlZq0pDYZ55sC0YeyGkq2AbdorKFJpISwc3U3ZQbXiLussvxew==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-19.2.21.tgz",
+      "integrity": "sha512-to3d4PZaufkUkWjlqM2cXQoYVNJUaUCYYw1g3b6ubCVHzSYZNCqXvreklMSKXwQoUhEHm2HOZ1h3WhcKEDiaag==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/BFF/v3/Angular/angular.ssr/package.json
+++ b/BFF/v3/Angular/angular.ssr/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/platform-server": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "@angular/ssr": "^19.2.0",
+    "@angular/ssr": "^19.2.21",
     "bootstrap": "^5.3.3",
     "express": "^4.18.2",
     "run-script-os": "*",


### PR DESCRIPTION
## Summary
Upgrade @angular/ssr from 19.2.3 to 21.2.0-rc.1, 21.1.5, 20.3.17, 19.2.21 to fix CVE-2026-27739.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-27739 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-27739` |
| **File** | `BFF/v3/Angular/angular.ssr/package-lock.json` (dependency: `@angular/ssr`) |
| **Assessment** | Likely exploitable |

**Description**: Angular SSR is vulnerable to SSRF and Header Injection via request handling pipeline

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-27739` flagged this pattern.

## Changes
- `BFF/v3/Angular/angular.ssr/package.json`
- `BFF/v3/Angular/angular.ssr/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
