### PR TITLE
Add Duende Storage configuration sample

### DIFF
--- a/IdentityServer/v8/Storage/AllowedRegionTokenRequestValidator.cs
+++ b/IdentityServer/v8/Storage/AllowedRegionTokenRequestValidator.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel;
+using Duende.IdentityServer.Validation;
+
+namespace Storage;
+
+internal sealed class AllowedRegionTokenRequestValidator(IRequestRegionResolver regionResolver)
+    : ICustomTokenRequestValidator
+{
+    public Task ValidateAsync(CustomTokenRequestValidationContext context, CancellationToken _)
+    {
+        ArgumentNullException.ThrowIfNull(context.Result);
+
+        var properties = context.Result.ValidatedRequest.Client.Properties;
+        if (!properties.TryGetValue(SampleData.AllowedRegionAttribute.Code.Value, out var allowedRegion))
+        {
+            return Task.CompletedTask;
+        }
+
+        var requestedRegion = regionResolver.Resolve();
+        if (!string.Equals(requestedRegion, allowedRegion, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Result = new TokenRequestValidationResult(
+                validatedRequest: context.Result.ValidatedRequest,
+                error: OidcConstants.TokenErrors.InvalidRequest,
+                errorDescription: $"The {SampleData.RegionHeaderName} header must match the client's allowed region."
+            );
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/IdentityServer/v8/Storage/Pages/Account/Login.cshtml
+++ b/IdentityServer/v8/Storage/Pages/Account/Login.cshtml
@@ -1,0 +1,213 @@
+@page
+@model Storage.Pages.Account.LoginModel
+@{
+    Layout = null;
+}
+
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign in | Duende IdentityServer</title>
+    <style>
+        :root {
+            --charcoal: #2a2929;
+            --blue-focus: rgba(116, 172, 251, .4);
+            --beige: #f3f2e9;
+            --error: #c5122c;
+
+            font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--charcoal);
+            background: var(--beige);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            display: grid;
+            min-height: 100vh;
+            margin: 0;
+            place-items: center;
+            padding: 2rem 1rem;
+        }
+
+        button,
+        input {
+            font: inherit;
+        }
+
+        main {
+            width: min(430px, 100%);
+        }
+
+        .login-card {
+            width: 100%;
+            padding: 2.5rem;
+            border: 1px solid #d9d9d9;
+            border-radius: 16px;
+            background: #fff;
+            box-shadow: 0 12px 32px rgba(42, 41, 41, .08);
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 2.25rem;
+            line-height: 1.15;
+            letter-spacing: -.03em;
+        }
+
+        .intro {
+            margin: .75rem 0 1.75rem;
+            color: #5c5c5c;
+            line-height: 1.6;
+        }
+
+        .credentials {
+            margin-bottom: 1.5rem;
+            padding: .8rem 1rem;
+            border-radius: 8px;
+            background: #d5ffe2;
+            color: #114f24;
+            font-size: .85rem;
+        }
+
+        .credentials code {
+            font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+            font-weight: 700;
+        }
+
+        .field {
+            margin-bottom: 1.1rem;
+        }
+
+        .field label {
+            display: block;
+            margin-bottom: .4rem;
+            font-size: .85rem;
+            font-weight: 600;
+        }
+
+        .field input {
+            width: 100%;
+            padding: .75rem .85rem;
+            border: 1px solid #bcbcbc;
+            border-radius: 6px;
+            color: var(--charcoal);
+            background: #fff;
+        }
+
+        .field input:focus-visible {
+            border-color: var(--charcoal);
+            outline: 2px solid var(--charcoal);
+            outline-offset: 2px;
+            box-shadow: 0 0 0 5px var(--blue-focus);
+        }
+
+        .field input.input-validation-error {
+            border-color: var(--error);
+        }
+
+        .field-validation-error {
+            display: block;
+            margin-top: .35rem;
+            color: var(--error);
+            font-size: .8rem;
+        }
+
+        .validation-summary-valid {
+            display: none;
+        }
+
+        .validation-summary-errors {
+            margin-bottom: 1rem;
+            padding: .75rem 1rem;
+            border-left: 3px solid var(--error);
+            background: #fff4f5;
+            color: var(--error);
+            font-size: .85rem;
+        }
+
+        .validation-summary-errors ul {
+            margin: 0;
+            padding-left: 1rem;
+        }
+
+        .submit {
+            width: 100%;
+            margin-top: .4rem;
+            padding: .8rem 1rem;
+            border: 1px solid var(--charcoal);
+            border-radius: 6px;
+            color: #fff;
+            background: var(--charcoal);
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .submit:focus-visible,
+        .back-link:focus-visible {
+            outline: 3px solid var(--charcoal);
+            outline-offset: 3px;
+            box-shadow: 0 0 0 6px var(--blue-focus);
+        }
+
+        .back-link {
+            display: inline-block;
+            margin-top: 1.5rem;
+            color: var(--charcoal);
+            font-size: .85rem;
+            font-weight: 500;
+            text-underline-offset: 3px;
+        }
+
+        @@media (max-width: 480px) {
+            .login-card {
+                padding: 2rem 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section class="login-card" aria-labelledby="login-title">
+            <h1 id="login-title">Sign in</h1>
+            @if (string.IsNullOrWhiteSpace(Model.Input.ReturnUrl))
+            {
+                <p class="intro">Start sign-in from one of the scenarios on the sample home page.</p>
+            }
+            else
+            {
+                <p class="intro">Continue the authorization flow and create a storage-backed session.</p>
+
+                <div class="credentials">
+                    Sample credentials: <code>alice</code> / <code>alice</code>
+                </div>
+
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly"></div>
+                    <input type="hidden" asp-for="Input.ReturnUrl">
+
+                    <div class="field">
+                        <label asp-for="Input.Username"></label>
+                        <input asp-for="Input.Username" autocomplete="username" placeholder="alice" autofocus>
+                        <span asp-validation-for="Input.Username"></span>
+                    </div>
+
+                    <div class="field">
+                        <label asp-for="Input.Password"></label>
+                        <input asp-for="Input.Password" autocomplete="current-password">
+                        <span asp-validation-for="Input.Password"></span>
+                    </div>
+
+                    <button class="submit" type="submit">Sign in</button>
+                </form>
+            }
+
+            <a class="back-link" href="/">Back to sample</a>
+        </section>
+    </main>
+</body>
+</html>

--- a/IdentityServer/v8/Storage/Pages/Account/Login.cshtml.cs
+++ b/IdentityServer/v8/Storage/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using Duende.IdentityModel;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Test;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Storage.Pages.Account;
+
+[AllowAnonymous]
+public sealed class LoginModel(
+    IIdentityServerInteractionService interaction,
+    TestUserStore users) : PageModel
+{
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public void OnGet(string? returnUrl) => Input.ReturnUrl = returnUrl;
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var context = await interaction.GetAuthorizationContextAsync(
+            Input.ReturnUrl,
+            HttpContext.RequestAborted);
+
+        if (context is null && !Url.IsLocalUrl(Input.ReturnUrl))
+        {
+            return BadRequest("The login request did not contain a valid return URL.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        if (!users.ValidateCredentials(Input.Username, Input.Password))
+        {
+            ModelState.AddModelError(string.Empty, "Invalid username or password.");
+            return Page();
+        }
+
+        var user = users.FindByUsername(Input.Username)
+            ?? throw new InvalidOperationException("The validated sample user could not be loaded.");
+
+        await HttpContext.SignInAsync(new IdentityServerUser(user.SubjectId)
+        {
+            DisplayName = user.Username,
+            AdditionalClaims = [.. user.Claims.Where(claim => claim.Type == JwtClaimTypes.Role)]
+        });
+
+        return Redirect(Input.ReturnUrl ?? "~/");
+    }
+
+    public sealed class InputModel
+    {
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        public string? ReturnUrl { get; set; }
+    }
+}

--- a/IdentityServer/v8/Storage/Pages/_ViewImports.cshtml
+++ b/IdentityServer/v8/Storage/Pages/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/IdentityServer/v8/Storage/Program.cs
+++ b/IdentityServer/v8/Storage/Program.cs
@@ -214,9 +214,13 @@ static Uri GetPublicBaseUri(string value)
 {
     if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
         uri.Scheme != Uri.UriSchemeHttps ||
-        !uri.IsLoopback)
+        !uri.IsLoopback ||
+        uri.AbsolutePath != "/" ||
+        !string.IsNullOrEmpty(uri.Query) ||
+        !string.IsNullOrEmpty(uri.Fragment))
     {
-        throw new InvalidOperationException("SampleBaseUrl must be an absolute HTTPS loopback URL.");
+        throw new InvalidOperationException(
+            "SampleBaseUrl must be an HTTPS loopback origin without a path, query, or fragment.");
     }
 
     return uri;

--- a/IdentityServer/v8/Storage/Program.cs
+++ b/IdentityServer/v8/Storage/Program.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using Duende.IdentityModel;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.Clients;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.Storage.Querying;
+using Duende.Storage.Schema;
+using Duende.Storage.Sqlite;
+using Microsoft.AspNetCore.HostFiltering;
+using Microsoft.AspNetCore.WebUtilities;
+using Storage;
+
+const string defaultBaseUrl = "https://localhost:5006";
+const string databaseName = "IdentityServerStorageSample";
+
+var builder = WebApplication.CreateBuilder(args);
+var publicBaseUri = GetPublicBaseUri(builder.Configuration["SampleBaseUrl"] ?? defaultBaseUrl);
+var publicBaseUrl = publicBaseUri.GetLeftPart(UriPartial.Authority);
+
+builder.Services.AddHttpClient();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddRazorPages();
+builder.Services
+    .AddAuthorizationBuilder()
+    .AddPolicy("admin", policy => policy.RequireClaim(JwtClaimTypes.Role, "admin"));
+
+builder.Services.Configure<HostFilteringOptions>(options => options.AllowedHosts = [publicBaseUri.Host]);
+builder.Services.AddScoped<IRequestRegionResolver, SimulatedRequestRegionResolver>();
+
+builder.Services
+    .AddIdentityServer(options =>
+    {
+        options.KeyManagement.Enabled = false;
+        options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
+    })
+    .AddDeveloperSigningCredential(persistKey: false)
+    .AddServerSideSessions()
+    .AddStorage(storage => storage.AddSqliteInMemoryStore(databaseName))
+    .AddInMemoryDataExtensionSchemas([SampleData.ClientSchema])
+    .AddTestUsers(SampleUsers.Users)
+    .AddCustomTokenRequestValidator<AllowedRegionTokenRequestValidator>();
+
+var app = builder.Build();
+
+await app.Services.GetRequiredService<IDatabaseSchema>().MigrateAsync(CancellationToken.None);
+await SampleData.InitializeAsync(app.Services, publicBaseUrl, CancellationToken.None);
+
+app.UseHostFiltering();
+app.UseRouting();
+app.UseIdentityServer();
+app.UseAuthorization();
+
+app.MapGet("/", () => Results.Content(
+    content: SamplePage.Create(publicBaseUrl),
+    contentType: "text/html")
+);
+
+app.MapGet("/sample/clients", async (
+    string? search,
+    IClientAdmin clientAdmin,
+    CancellationToken ct) =>
+{
+    var request = QueryRequest.Create<ClientFilter, ClientSortField>(
+        filter: new ClientFilter { ClientId = search }
+    );
+
+    var result = await clientAdmin.QueryAsync(request, ct);
+
+    return Results.Ok(new
+    {
+        result.Items,
+        result.TotalCount,
+        result.HasMoreData,
+        result.NextToken
+    });
+
+}).RequireAuthorization("admin");
+
+app.MapGet("/sample/sessions", async (
+    IServerSideSessionStore sessionStore,
+    CancellationToken ct) =>
+{
+    var result = await sessionStore.QuerySessionsAsync(ct);
+    return Results.Ok(new
+    {
+        Sessions = result.Results.Select(session => new
+        {
+            session.SubjectId,
+            session.DisplayName,
+            session.Created,
+            session.Renewed,
+            session.Expires
+        }),
+        result.Results.Count,
+        result.HasNextResults
+    });
+
+}).RequireAuthorization("admin");
+
+app.MapGet("/home/error", async (
+    string? errorId,
+    IIdentityServerInteractionService interaction,
+    CancellationToken ct) =>
+{
+    var error = await interaction.GetErrorContextAsync(errorId, ct);
+    return Results.Problem(
+        statusCode: StatusCodes.Status400BadRequest,
+        title: error?.Error ?? "IdentityServer request error",
+        detail: error?.ErrorDescription);
+
+}).AllowAnonymous();
+
+app.MapGet("/sample/login", (HttpContext httpContext) =>
+{
+    var state = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+    var verifier = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+    var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+    var cookieOptions = new CookieOptions
+    {
+        HttpOnly = true,
+        IsEssential = true,
+        MaxAge = TimeSpan.FromMinutes(5),
+        SameSite = SameSiteMode.Lax,
+        Secure = true
+    };
+
+    httpContext.Response.Cookies.Append(SamplePage.StateCookie, state, cookieOptions);
+    httpContext.Response.Cookies.Append(SamplePage.VerifierCookie, verifier, cookieOptions);
+
+    var authorizeUrl = QueryHelpers.AddQueryString(
+        uri: "/connect/authorize",
+        queryString: new Dictionary<string, string?>
+        {
+            ["client_id"] = SampleData.InteractiveClientId,
+            ["redirect_uri"] = $"{publicBaseUrl}/sample/callback",
+            ["response_type"] = "code",
+            ["scope"] = "openid profile sample-api",
+            ["code_challenge"] = challenge,
+            ["code_challenge_method"] = "S256",
+            ["state"] = state
+        });
+
+    return Results.Redirect(authorizeUrl);
+});
+
+app.MapGet("/sample/callback", async (
+    HttpContext httpContext,
+    IHttpClientFactory httpClientFactory,
+    CancellationToken ct) =>
+{
+    var returnedState = httpContext.Request.Query["state"].ToString();
+    var expectedState = httpContext.Request.Cookies[SamplePage.StateCookie];
+    var verifier = httpContext.Request.Cookies[SamplePage.VerifierCookie];
+
+    httpContext.Response.Cookies.Delete(SamplePage.StateCookie);
+    httpContext.Response.Cookies.Delete(SamplePage.VerifierCookie);
+
+    if (string.IsNullOrEmpty(returnedState) ||
+        string.IsNullOrEmpty(expectedState) ||
+        !CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(returnedState),
+            Encoding.UTF8.GetBytes(expectedState)) ||
+        string.IsNullOrEmpty(verifier))
+    {
+        return Results.BadRequest("The authorization response state or PKCE verifier is invalid.");
+    }
+
+    var code = httpContext.Request.Query["code"].ToString();
+    if (string.IsNullOrEmpty(code))
+    {
+        return Results.BadRequest("The authorization response did not contain a code.");
+    }
+
+    using var tokenRequest = new HttpRequestMessage(
+        method: HttpMethod.Post,
+        requestUri: $"{publicBaseUrl}/connect/token")
+    {
+        Content = new FormUrlEncodedContent(
+        [
+            new("grant_type", "authorization_code"),
+            new("client_id", SampleData.InteractiveClientId),
+            new("code", code),
+            new("redirect_uri", $"{publicBaseUrl}/sample/callback"),
+            new("code_verifier", verifier)
+        ])
+    };
+
+    tokenRequest.Headers.Add(SampleData.RegionHeaderName, SampleData.AllowedRegion);
+
+    var client = httpClientFactory.CreateClient();
+    using var response = await client.SendAsync(tokenRequest, ct);
+    var content = await response.Content.ReadAsStringAsync(ct);
+
+    httpContext.Response.Headers.CacheControl = "no-store";
+    httpContext.Response.Headers.Pragma = "no-cache";
+
+    return Results.Content(
+        content,
+        contentType: response.Content.Headers.ContentType?.ToString() ?? "application/json",
+        statusCode: (int)response.StatusCode);
+});
+
+app.MapRazorPages();
+
+await app.RunAsync();
+
+static Uri GetPublicBaseUri(string value)
+{
+    if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+        uri.Scheme != Uri.UriSchemeHttps ||
+        !uri.IsLoopback)
+    {
+        throw new InvalidOperationException("SampleBaseUrl must be an absolute HTTPS loopback URL.");
+    }
+
+    return uri;
+}

--- a/IdentityServer/v8/Storage/Properties/launchSettings.json
+++ b/IdentityServer/v8/Storage/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "Storage Sample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "applicationUrl": "https://localhost:5006",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "SampleBaseUrl": "https://localhost:5006"
+      }
+    }
+  }
+}

--- a/IdentityServer/v8/Storage/README.md
+++ b/IdentityServer/v8/Storage/README.md
@@ -1,0 +1,52 @@
+# Duende Storage sample
+
+This sample runs IdentityServer with configuration and operational data stored in a shared in-memory SQLite database through Duende Storage. It uses the IdentityServer administration APIs to create all IdentityServer configuration at startup and registers a fixed in-memory schema for client extension properties.
+
+The sample demonstrates:
+
+- defining a fixed client data-extension schema and its typed `allowed_region` attribute in the sample;
+- creating scopes, identity resources, clients, secrets, and extension-property values with the administration APIs;
+- obtaining a client-credentials token from configuration loaded through Duende Storage;
+- enforcing an `allowed_region` client extension property in a custom token-request validator;
+- signing in a test user with authorization code and PKCE to create a storage-backed server-side session; and
+- searching stored clients and inspecting stored sessions.
+
+## Run the sample
+
+The sample uses the latest prerelease packages required by this functionality:
+
+- `Duende.IdentityServer` `8.1.0-preview.3`
+- `Duende.Storage.Sqlite` `2.0.0-preview.2`
+
+From this directory, run:
+
+```console
+dotnet run
+```
+
+Open `https://localhost:5006` if the browser does not open automatically. The database is held in memory and is reset whenever the process stops.
+
+## Client credentials and the region extension
+
+`SampleData.ClientSchema` defines the fixed schema passed to `AddInMemoryDataExtensionSchemas`. The machine and interactive clients set its typed `allowed_region` attribute through `CreateClient.ExtendedProperties`.
+
+Request a token with the region allowed by the client's stored `allowed_region` property:
+
+```console
+curl --fail-with-body -X POST "https://localhost:5006/connect/token" -H "Content-Type: application/x-www-form-urlencoded" -H "X-Simulated-Region: eu-west" -d "grant_type=client_credentials&client_id=storage-sample-machine&client_secret=storage-sample-secret&scope=sample-api"
+```
+
+Change the header to `X-Simulated-Region: us-east` to receive an `invalid_request` response from the custom token-request validator.
+
+The region header is caller-controlled only to make the behavior easy to exercise. Production systems must resolve region or tenancy information from a trusted source.
+
+## User token and server-side session
+
+1. Select **Start the authorization code flow with PKCE** on the home page.
+2. Sign in with username `alice` and password `alice`.
+3. The callback exchanges the authorization code and displays the token response.
+4. Return to the home page and open the client search and server-side session links.
+
+The client search uses `IClientAdmin.QueryAsync`. The session endpoint uses `IServerSideSessionStore` and shows the session persisted as operational data. Both endpoints require the sample user's `admin` claim rather than allowing any authenticated user.
+
+The callback displays the raw token response to keep the sample focused on IdentityServer storage. A production relying party must validate tokens before using them.

--- a/IdentityServer/v8/Storage/SampleData.cs
+++ b/IdentityServer/v8/Storage/SampleData.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Duende.IdentityServer;
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.ApiScopes;
+using Duende.IdentityServer.Admin.Clients;
+using Duende.IdentityServer.Admin.IdentityResources;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores.Storage;
+using Duende.Storage;
+using Duende.Storage.EntityAttributeValue;
+using SecretHashAlgorithm = Duende.IdentityServer.Admin.SecretHashAlgorithm;
+
+namespace Storage;
+
+internal static class SampleData
+{
+    internal const string AllowedRegion = "eu-west";
+    internal const string ClientCredentialsClientId = "storage-sample-machine";
+    internal const string ClientSecret = "storage-sample-secret";
+    internal const string InteractiveClientId = "storage-sample-interactive";
+    internal const string RegionHeaderName = "X-Simulated-Region";
+
+    internal static readonly TypedAttributeDefinition<string> AllowedRegionAttribute =
+        new(AttributeCode.Create("allowed_region"), new ScalarAttributeType(ScalarDataType.String));
+
+    internal static readonly SchemaConfiguration ClientSchema = new()
+    {
+        SchemaId = SchemaId.Client,
+        DisplayName = "Client",
+        Description = "Extended attributes used by the storage sample.",
+        AttributeDefinitions = [AllowedRegionAttribute]
+    };
+
+    internal static async Task InitializeAsync(
+        IServiceProvider services,
+        string sampleBaseUrl,
+        CancellationToken ct)
+    {
+        using var scope = services.CreateScope();
+        var provider = scope.ServiceProvider;
+
+        await EnsureApiScopeAsync(provider.GetRequiredService<IApiScopeAdmin>(), ct);
+        await EnsureIdentityResourceAsync(
+            provider.GetRequiredService<IIdentityResourceAdmin>(),
+            IdentityServerConstants.StandardScopes.OpenId,
+            ["sub"],
+            ct);
+        await EnsureIdentityResourceAsync(
+            provider.GetRequiredService<IIdentityResourceAdmin>(),
+            IdentityServerConstants.StandardScopes.Profile,
+            ["name"],
+            ct);
+        await EnsureClientAsync(
+            provider.GetRequiredService<IClientAdmin>(),
+            CreateMachineClient(),
+            ct);
+        await EnsureClientAsync(
+            provider.GetRequiredService<IClientAdmin>(),
+            CreateInteractiveClient(sampleBaseUrl),
+            ct);
+    }
+
+    private static async Task EnsureApiScopeAsync(IApiScopeAdmin admin, CancellationToken ct)
+    {
+        if ((await admin.GetByNameAsync("sample-api", ct)).Found)
+        {
+            return;
+        }
+
+        var result = await admin.CreateAsync(
+            new CreateApiScope
+            {
+                Name = "sample-api",
+                DisplayName = "Storage sample API"
+            },
+            ct);
+
+        EnsureSuccess(result, "sample-api scope");
+    }
+
+    private static async Task EnsureIdentityResourceAsync(
+        IIdentityResourceAdmin admin,
+        string name,
+        List<string> userClaims,
+        CancellationToken ct)
+    {
+        if ((await admin.GetByNameAsync(name, ct)).Found)
+        {
+            return;
+        }
+
+        var result = await admin.CreateAsync(
+            new CreateIdentityResource
+            {
+                Name = name,
+                DisplayName = name,
+                UserClaims = userClaims
+            },
+            ct);
+
+        EnsureSuccess(result, $"{name} identity resource");
+    }
+
+    private static async Task EnsureClientAsync(
+        IClientAdmin admin,
+        CreateClient client,
+        CancellationToken ct)
+    {
+        if ((await admin.GetByClientIdAsync(client.ClientId, ct)).Found)
+        {
+            return;
+        }
+
+        var result = await admin.CreateAsync(client, ct);
+        EnsureSuccess(result, $"{client.ClientId} client");
+    }
+
+    private static CreateClient CreateMachineClient()
+    {
+        var client = new CreateClient
+        {
+            ClientId = ClientCredentialsClientId,
+            ClientName = "Storage sample machine client",
+            AllowedGrantTypes = [GrantType.ClientCredentials],
+            AllowedScopes = ["sample-api"],
+            ClientSecrets =
+            [
+                new CreateClientSecret
+                {
+                    PlaintextValue = ClientSecret,
+                    HashAlgorithm = SecretHashAlgorithm.Sha256
+                }
+            ]
+        };
+        client.ExtendedProperties.Set(AllowedRegionAttribute, AllowedRegion);
+        return client;
+    }
+
+    private static CreateClient CreateInteractiveClient(string sampleBaseUrl)
+    {
+        var client = new CreateClient
+        {
+            ClientId = InteractiveClientId,
+            ClientName = "Storage sample interactive client",
+            RequireClientSecret = false,
+            RequireConsent = false,
+            AllowedGrantTypes = [GrantType.AuthorizationCode],
+            AllowedScopes = ["openid", "profile", "sample-api"],
+            RedirectUris = [$"{sampleBaseUrl}/sample/callback"]
+        };
+        client.ExtendedProperties.Set(AllowedRegionAttribute, AllowedRegion);
+        return client;
+    }
+
+    private static void EnsureSuccess<TId>(SaveResult<TId> result, string item)
+        where TId : notnull
+    {
+        if (result.IsSuccess)
+        {
+            return;
+        }
+
+        var errors = result.Errors is null
+            ? "No error details were returned."
+            : string.Join(Environment.NewLine, result.Errors.Select(error => $"{error.Code}: {error.Message}"));
+
+        throw new InvalidOperationException($"Could not create {item}.{Environment.NewLine}{errors}");
+    }
+}

--- a/IdentityServer/v8/Storage/SamplePage.cs
+++ b/IdentityServer/v8/Storage/SamplePage.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+
+namespace Storage;
+
+internal static class SamplePage
+{
+    internal const string StateCookie = "storage_sample_state";
+    internal const string VerifierCookie = "storage_sample_verifier";
+
+    internal static string Create(string baseUrl)
+    {
+        var encodedBaseUrl = WebUtility.HtmlEncode(baseUrl);
+
+        return $$"""
+            <!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+              <title>Duende Storage IdentityServer sample</title>
+              <style>
+                body { font-family: system-ui, sans-serif; line-height: 1.5; margin: 2rem auto; max-width: 60rem; padding: 0 1rem; }
+                code, pre { background: #f3f4f6; border-radius: .25rem; }
+                code { padding: .1rem .25rem; }
+                pre { overflow-x: auto; padding: 1rem; white-space: pre-wrap; }
+              </style>
+            </head>
+            <body>
+              <h1>Storage-backed IdentityServer</h1>
+              <p>
+                This host stores IdentityServer configuration and operational data in an in-memory SQLite database.
+                Startup registers a fixed in-memory schema, then creates scopes, identity resources, clients, and typed
+                client extension-property values through the administration APIs.
+              </p>
+
+              <h2>Inspect configuration</h2>
+              <p><a href="/.well-known/openid-configuration">Open the discovery document</a>.</p>
+              <p>
+                Complete the user sign-in below, then
+                <a href="/sample/clients?search=storage-sample">search clients through IClientAdmin</a>.
+              </p>
+
+              <h2>Client credentials</h2>
+              <p>
+                The custom token request validator compares <code>X-Simulated-Region</code> with the client's stored
+                <code>allowed_region</code> property. The header is intentionally caller-controlled for this local demo.
+                A production resolver must use trusted deployment or network data instead.
+              </p>
+              <pre>curl --fail-with-body -X POST "{{encodedBaseUrl}}/connect/token" -H "Content-Type: application/x-www-form-urlencoded" -H "X-Simulated-Region: eu-west" -d "grant_type=client_credentials&amp;client_id={{SampleData.ClientCredentialsClientId}}&amp;client_secret={{SampleData.ClientSecret}}&amp;scope=sample-api"</pre>
+              <p>Change the region to <code>us-east</code> to see the extension reject the request.</p>
+
+              <h2>User token and server-side session</h2>
+              <p>
+                <a href="/sample/login">Start the authorization code flow with PKCE</a>.
+                Sign in as <code>alice</code> with password <code>alice</code>. The callback exchanges the code and
+                displays the token response.
+              </p>
+              <p><a href="/sample/sessions">Inspect storage-backed server-side sessions</a> after signing in.</p>
+            </body>
+            </html>
+            """;
+    }
+}

--- a/IdentityServer/v8/Storage/SampleUsers.cs
+++ b/IdentityServer/v8/Storage/SampleUsers.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Security.Claims;
+using Duende.IdentityModel;
+using Duende.IdentityServer.Test;
+
+namespace Storage;
+
+internal static class SampleUsers
+{
+    internal static List<TestUser> Users { get; } =
+    [
+        new()
+        {
+            SubjectId = "1",
+            Username = "alice",
+            Password = "alice",
+            Claims =
+            {
+                new Claim(JwtClaimTypes.Name, "Alice Smith"),
+                new Claim(JwtClaimTypes.Email, "alice@example.com"),
+                new Claim(JwtClaimTypes.Role, "admin")
+            }
+        }
+    ];
+}

--- a/IdentityServer/v8/Storage/SimulatedRequestRegionResolver.cs
+++ b/IdentityServer/v8/Storage/SimulatedRequestRegionResolver.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Storage;
+
+internal interface IRequestRegionResolver
+{
+    string? Resolve();
+}
+
+internal sealed class SimulatedRequestRegionResolver(IHttpContextAccessor httpContextAccessor)
+    : IRequestRegionResolver
+{
+    public string? Resolve() =>
+        httpContextAccessor.HttpContext?.Request.Headers[SampleData.RegionHeaderName].ToString();
+}

--- a/IdentityServer/v8/Storage/Storage.csproj
+++ b/IdentityServer/v8/Storage/Storage.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Duende.IdentityModel" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="8.1.0-preview.3" />
+    <PackageReference Include="Duende.Storage.Sqlite" VersionOverride="2.0.0-preview.2" />
+    <!-- Override the vulnerable SQLite native library resolved by the preview provider. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" VersionOverride="2.1.13" />
+  </ItemGroup>
+
+</Project>

--- a/IdentityServer/v8/Storage/Storage.slnx
+++ b/IdentityServer/v8/Storage/Storage.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <File Path="README.md" />
+  <Project Path="Storage.csproj" />
+</Solution>

--- a/samples.slnx
+++ b/samples.slnx
@@ -658,6 +658,10 @@
   <Folder Name="/IdentityServer/v8/Spaces/tests/">
     <Project Path="IdentityServer/v8/Spaces/tests/Spaces.PlaywrightTests/Spaces.PlaywrightTests.csproj" />
   </Folder>
+  <Folder Name="/IdentityServer/v8/Storage/">
+    <File Path="IdentityServer/v8/Storage/README.md" />
+    <Project Path="IdentityServer/v8/Storage/Storage.csproj" />
+  </Folder>
   <Folder Name="/IdentityServer/v8/TokenExchange/">
     <Project Path="IdentityServer/v8/TokenExchange/Client/Client.csproj" />
     <Project Path="IdentityServer/v8/TokenExchange/IdentityServerHost/IdentityServerHost.csproj" />


### PR DESCRIPTION
This sample demonstrates how IdentityServer configuration and operational data can be stored in Duende.Storage and managed through the administration APIs.

## Summary

- Host IdentityServer with a shared in-memory SQLite store and a fixed in-memory client extension schema.
- Seed API scopes, identity resources, and clients through the administration APIs.
- Demonstrate client-credentials token issuance, authorization code with PKCE, storage-backed server-side sessions, and authenticated client and session searches.
- Define an `allowed_region` client extension property and enforce it in a custom token request validator.
- Include a compact login page, runnable launch profile, dedicated solution, and setup documentation.

## Notes

The simulated `X-Simulated-Region` request header is intentionally caller-controlled for demonstration purposes and is not a production trust source. Preview package overrides are scoped to this sample, including a patched SQLite native dependency version.